### PR TITLE
Remove Island Home help text if home integration is disabled

### DIFF
--- a/src/main/java/net/mohron/skyclaims/command/CommandIsland.java
+++ b/src/main/java/net/mohron/skyclaims/command/CommandIsland.java
@@ -24,6 +24,7 @@ import static net.mohron.skyclaims.PluginInfo.VERSION;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.api.NucleusAPI;
 import net.mohron.skyclaims.PluginInfo;
 import net.mohron.skyclaims.command.team.CommandDemote;
 import net.mohron.skyclaims.command.team.CommandInvite;
@@ -160,7 +161,9 @@ public class CommandIsland extends CommandBase {
             ));
         }
 
-        if (src.hasPermission(Permissions.COMMAND_HOME)) {
+        if (src.hasPermission(Permissions.COMMAND_HOME)
+            && PLUGIN.getConfig().getIntegrationConfig().getNucleus().isHomesEnabled()
+            && NucleusAPI.getHomeService().isPresent()) {
             helpText.add(Text.of(
                 TextColors.AQUA, Text.builder("is home").onClick(TextActions.runCommand("/is home")),
                 TextColors.DARK_GRAY, " - ",


### PR DESCRIPTION
Small improvement to remove `is home` from the help menu when the command is disabled.